### PR TITLE
Added missing dependency in the doc for Termux and check error code f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please note that root access is required.
 **Installing requirements**
  ```
  pkg install -y root-repo
- pkg install -y git tsu python wpa-supplicant pixiewps iw
+ pkg install -y git tsu python wpa-supplicant pixiewps iw openssl
  ```
 **Getting OneShot**
  ```

--- a/oneshot.py
+++ b/oneshot.py
@@ -439,8 +439,13 @@ class Companion:
         self.wpas = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,
                                      stderr=subprocess.STDOUT, encoding='utf-8', errors='replace')
         # Waiting for wpa_supplicant control interface initialization
-        while not os.path.exists(self.wpas_ctrl_path):
-            pass
+        while True:
+            ret = self.wpas.poll()
+            if ret is not None and ret != 0:
+                raise ValueError('wpa_supplicant returned an error: ' + self.wpas.communicate()[0])
+            if os.path.exists(self.wpas_ctrl_path):
+                break
+            time.sleep(.1)
 
     def sendOnly(self, command):
         """Sends command to wpa_supplicant"""


### PR DESCRIPTION
…rom wpa_supplicant subprocess

This pull request corrects this issue:
https://github.com/drygdryg/OneShot/issues/71

If `openssl` is not installed, execution will not stall but will output:
```
~ $ sudo python OneShot/oneshot.py -i wlan0  --pbc
[*] Running wpa_supplicant…
Traceback (most recent call last):
  File "/data/data/com.termux/files/home/OneShot/oneshot.py", line 1202, in <module>
    companion = Companion(args.interface, args.write, print_debug=args.verbose)
  File "/data/data/com.termux/files/home/OneShot/oneshot.py", line 416, in __init__
    self.__init_wpa_supplicant()
  File "/data/data/com.termux/files/home/OneShot/oneshot.py", line 446, in __init_wpa_supplicant
    raise ValueError('wpa_supplicant returned an error: ' + self.wpas.communicate()[0])
ValueError: wpa_supplicant returned an error: CANNOT LINK EXECUTABLE "wpa_supplicant": library "libssl.so.3" not found: needed by main executable

Exception ignored in: <function Companion.__del__ at 0x7466db0550>
Traceback (most recent call last):
  File "/data/data/com.termux/files/home/OneShot/oneshot.py", line 829, in __del__
    self.cleanup()
  File "/data/data/com.termux/files/home/OneShot/oneshot.py", line 822, in cleanup
    self.retsock.close()
AttributeError: 'Companion' object has no attribute 'retsock'
```
